### PR TITLE
Sort client exports by name in client index.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proofgeist/fmdapi",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "FileMaker Data API client",
   "main": "dist/index.js",
   "repository": "git@github.com:proofgeist/fm-dapi.git",


### PR DESCRIPTION
During heavy development of a project (where updated `codegen` code frequently needs to be merged from new branches), there's a tendency for git conflicts to occur on the generated `index.ts` file due to the order of the exports changing. This updates `codegen` to always sort exports alphabetically.