### PR TITLE
fixes #21

### DIFF
--- a/.changeset/old-hounds-double.md
+++ b/.changeset/old-hounds-double.md
@@ -1,0 +1,5 @@
+---
+"@proofgeist/fmdapi": patch
+---
+
+fix Codegen on Windows systems

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proofgeist/fmdapi",
-  "version": "3.0.9",
+  "version": "3.0.10-beta.4",
   "description": "FileMaker Data API client",
   "main": "dist/index.js",
   "repository": "git@github.com:proofgeist/fm-dapi.git",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { generateSchemas } from "./utils";
 import path from "path";
 import { GenerateSchemaOptions } from "./utils/codegen";
 import { config } from "dotenv";
+import { pathToFileURL } from "url";
 
 const defaultConfigPaths = ["./fmschema.config.mjs", "./fmschema.config.js"];
 type ConfigArgs = {
@@ -52,11 +53,16 @@ async function runCodegen({ configLocation }: ConfigArgs) {
     return process.exit(1);
   });
 
-  const module: { config: GenerateSchemaOptions } = await import(
-    configLocation
-  );
-  let config = module.config;
-  if (!config) {
+  let config;
+
+  console.log(`🔍 Reading config from ${configLocation}`);
+
+  if (configLocation.endsWith(".mjs")) {
+    const module: { config: GenerateSchemaOptions } = await import(
+      pathToFileURL(configLocation).toString()
+    );
+    config = module.config;
+  } else {
     config = require(configLocation);
   }
   if (!config) {


### PR DESCRIPTION
Hi, 
I did some research on my own to fix #21. 
There is more info on the `//?/` [here](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#namespaces) if you are interested. 

Apparently the module import requires the `file:\\\` prefix and the `pathToFileURL` function resolves this. 

I used the 3.0.10 beta 3 source. All tests pass on my windows machine and on ubuntu in wsl. 