### PR TITLE
add export for `tokenStores` and fix `listAll`& `findAll` default offset

### DIFF
--- a/.changeset/empty-poems-hug.md
+++ b/.changeset/empty-poems-hug.md
@@ -1,0 +1,6 @@
+---
+"@proofgeist/fmdapi": patch
+---
+
+add export for `tokenStores`
+adjust offset for automatic pagination functions

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "./dist/wv": {
       "import": "./dist/wv.js",
       "types": "./dist/wv.d.ts"
-    }
+    },
+    "./dist/tokenStore/*.js": "./dist/tokenStore/*.js"
   },
   "scripts": {
     "prepublishOnly": "tsc",

--- a/src/client.ts
+++ b/src/client.ts
@@ -357,7 +357,7 @@ function DataApi<
   ): Promise<FMRecord<T, U>[]> {
     let runningData: GetResponse<T, U>["data"] = [];
     const limit = args?.limit ?? 100;
-    let offset = args?.offset ?? 0;
+    let offset = args?.offset ?? 1;
 
     // eslint-disable-next-line no-constant-condition
     while (true) {
@@ -584,7 +584,7 @@ function DataApi<
   ): Promise<FMRecord<T, U>[]> {
     let runningData: GetResponse<T, U>["data"] = [];
     const limit = args.limit ?? 100;
-    let offset = args.offset ?? 0;
+    let offset = args.offset ?? 1;
     // eslint-disable-next-line no-constant-condition
     while (true) {
       const data = await find<T, U>({

--- a/src/client.ts
+++ b/src/client.ts
@@ -315,7 +315,7 @@ function DataApi<
     if ("limit" in params && params.limit !== undefined)
       delete Object.assign(params, { _limit: params.limit })["limit"];
     if ("offset" in params && params.offset !== undefined) {
-      if (params.offset === 0) delete params.offset;
+      if (params.offset >= 1) delete params.offset;
       else delete Object.assign(params, { _offset: params.offset })["offset"];
     }
     if ("sort" in params && params.sort !== undefined)
@@ -524,7 +524,7 @@ function DataApi<
 
     // rename and refactor limit, offset, and sort keys for this request
     if ("offset" in params && params.offset !== undefined) {
-      if (params.offset === 0) delete params.offset;
+      if (params.offset >= 1) delete params.offset;
     }
 
     const data = (await request({

--- a/src/wv.ts
+++ b/src/wv.ts
@@ -186,7 +186,7 @@ function DataApi<
   ): Promise<FMRecord<T, U>[]> {
     let runningData: GetResponse<T, U>["data"] = [];
     const limit = args?.limit ?? 100;
-    let offset = args?.offset ?? 0;
+    let offset = args?.offset ?? 1;
     const myArgs = args ?? {};
 
     // eslint-disable-next-line no-constant-condition
@@ -351,7 +351,7 @@ function DataApi<
   ): Promise<FMRecord<T, U>[]> {
     let runningData: GetResponse<T, U>["data"] = [];
     const limit = args.limit ?? 100;
-    const offset = args.offset ?? 0;
+    const offset = args.offset ?? 1;
     // eslint-disable-next-line no-constant-condition
     while (true) {
       const data = await find<T, U>({ ...args, ignoreEmptyResult: true });


### PR DESCRIPTION
Hi, 

I had similar problems like described in #47 (somewhere since `>= 3.2.3`) when trying to import any of the `tokenStore` in the `fmschema.config.mjs` according to documentation:

```js
import { fileTokenStore } from "@proofgeist/fmdapi/dist/tokenStore/file.js";
import { memoryStore } from "@proofgeist/fmdapi/dist/tokenStore/memory.js";

/**
 * @type {import("@proofgeist/fmdapi/dist/utils/codegen").GenerateSchemaOptions}
 */
export const config = {
  schemas: [
    ...
  ],
  tokenStore: process.env.NODE_ENV == "development" ? fileTokenStore() : memoryStore(),
};
``` 

I get the the following error with `3.3.2`:
```
🔍 Reading config from <path>/apps/rgk/fmschema.config.mjs
node:internal/modules/esm/resolve:302
  return new ERR_PACKAGE_PATH_NOT_EXPORTED(
         ^

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './dist/tokenStore/file.js' is not defined by "exports" in <path>/node_modules/@proofgeist/fmdapi/package.json imported from <path>/apps/rgk/fmschema.config.mjs
    at exportsNotFound (node:internal/modules/esm/resolve:302:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:649:9)
    at packageResolve (node:internal/modules/esm/resolve:827:14)
    at moduleResolve (node:internal/modules/esm/resolve:901:20)
    at defaultResolve (node:internal/modules/esm/resolve:1121:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:396:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:365:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:240:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:85:39)
    at link (node:internal/modules/esm/module_job:84:36) {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}

Node.js v21.5.0
error Command failed with exit code 1.
```

With the added glob export the codegen works fine. 

I originally just wanted to add the "tokenStore/index.js". 
But in that case the `@upstash/redis` is required, which should not be mandatory to install. 
