### PR TITLE
ottoapi key helpers

### DIFF
--- a/.changeset/little-bikes-fly.md
+++ b/.changeset/little-bikes-fly.md
@@ -1,0 +1,5 @@
+---
+"@proofgeist/fmdapi": patch
+---
+
+Add type validation helper functions for detecting Otto API keys

--- a/src/client.ts
+++ b/src/client.ts
@@ -25,16 +25,17 @@ import {
 } from "./client-types.js";
 import type { TokenStoreDefinitions } from "./tokenStore/types.js";
 import { memoryStore } from "./tokenStore/memory.js";
+import { Otto3APIKey, OttoFMSAPIKey } from "./utils/utils.js";
 
 function asNumber(input: string | number): number {
   return typeof input === "string" ? parseInt(input) : input;
 }
 type OttoAuth =
   | {
-      apiKey: `KEY_${string}`;
+      apiKey: Otto3APIKey;
       ottoPort?: number;
     }
-  | { apiKey: `dk_${string}`; ottoPort?: never };
+  | { apiKey: OttoFMSAPIKey; ottoPort?: never };
 
 type UserPasswordAuth = { username: string; password: string };
 export function isOttoAuth(auth: ClientObjectProps["auth"]): auth is OttoAuth {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { S, L, U } from "ts-toolbelt";
 
 type TransformedFields<T extends Record<string, any>> = U.Merge<
@@ -23,4 +24,18 @@ export function removeFMTableNames<T extends Record<string, any>>(
     }
   }
   return newObj;
+}
+
+export type Otto3APIKey = `KEY_${string}`;
+export type OttoFMSAPIKey = `dk_${string}`;
+export type OttoAPIKey = Otto3APIKey | OttoFMSAPIKey;
+
+export function isOtto3APIKey(key: string): key is Otto3APIKey {
+  return key.startsWith("KEY_");
+}
+export function isOttoFMSAPIKey(key: string): key is OttoFMSAPIKey {
+  return key.startsWith("dk_");
+}
+export function isOttoAPIKey(key: string): key is OttoAPIKey {
+  return isOtto3APIKey(key) || isOttoFMSAPIKey(key);
 }


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces type validation helper functions for detecting Otto API keys. It also modifies the `OttoAuth` type to use these new helper functions.
> 
> ## What changed
> - Added new type validation helper functions `isOtto3APIKey`, `isOttoFMSAPIKey`, and `isOttoAPIKey` in `utils.ts`.
> - Defined new types `Otto3APIKey`, `OttoFMSAPIKey`, and `OttoAPIKey` in `utils.ts`.
> - Modified `OttoAuth` type in `client.ts` to use the new types `Otto3APIKey` and `OttoFMSAPIKey`.
> 
> ## Why make this change
> This change improves the type safety of the application by ensuring that API keys are of the correct type. This will help prevent bugs and errors related to incorrect or malformed API keys.
</details>