### PR TITLE
[fix] Remove redundant `setToken`

### DIFF
--- a/.changeset/big-needles-compete.md
+++ b/.changeset/big-needles-compete.md
@@ -1,0 +1,5 @@
+---
+"@proofgeist/fmdapi": patch
+---
+
+[fix] Removed the redundant setToken call at the end of getToken method

--- a/src/adapters/fetch.ts
+++ b/src/adapters/fetch.ts
@@ -65,7 +65,6 @@ export class FetchAdapter extends BaseFetchAdapter {
       this.tokenStore.setToken(this.getTokenKey(), token);
     }
 
-    this.tokenStore.setToken(this.getTokenKey(), token);
     return token;
   };
 


### PR DESCRIPTION
# Summary
This PR removes unnecessary duplicate `setToken` call in `FetchAdapter`.

# Description
Currently, in the `getToken` method of `FetchAdapter`, there are two `setToken` calls:

1. First call inside the token fetch block:
```typescript
if (!token) {
  // ... token fetch logic ...
  this.tokenStore.setToken(this.getTokenKey(), token);
}
```

2. Second redundant call outside the block:
```typescript
this.tokenStore.setToken(this.getTokenKey(), token);
```

This second `setToken` call is unnecessary because:
- If a new token was fetched, it's already been stored by the first call
- If we retrieved an existing token, there's no need to store it again

## Changes
- Removed the redundant `setToken` call at the end of `getToken` method
