### PR TITLE
feat: Allow layoutMetadata without args when layout configured on client

### DIFF
--- a/.changeset/fix-layoutmetadata-optional-args.md
+++ b/.changeset/fix-layoutmetadata-optional-args.md
@@ -1,0 +1,5 @@
+---
+"@proofgeist/fmdapi": patch
+---
+
+Allow `layoutMetadata` to be called without arguments when layout is pre-configured on the client. 

--- a/src/client.ts
+++ b/src/client.ts
@@ -419,16 +419,19 @@ function DataApi<
   }
 
   async function _layoutMetadata(
-    args: Opts["layout"] extends string
+    args?: Opts["layout"] extends string
       ? { timeout?: number } & Partial<WithLayout> & FetchOptions
       : { timeout?: number } & WithLayout & FetchOptions,
   ) {
-    const { layout, ...params } = args;
+    const { layout = options.layout, ...restArgs } = args ?? {};
+    // Explicitly define the type for params based on FetchOptions
+    const params: FetchOptions & { timeout?: number } = restArgs;
+
     if (layout === undefined) throw new Error("Layout is required");
     return await layoutMetadata({
       layout,
-      fetch: params.fetch,
-      timeout: params.timeout,
+      fetch: params.fetch, // Now should correctly resolve to undefined if not present
+      timeout: params.timeout, // Now should correctly resolve to undefined if not present
     });
   }
 

--- a/test/client-methods.test.ts
+++ b/test/client-methods.test.ts
@@ -212,6 +212,79 @@ describe("other methods", () => {
     expect(resp.scripts[1] as ScriptOrFolder).toHaveProperty("isFolder");
   });
 
+  it("should retrieve layout metadata with only the layout parameter", async () => {
+    const client = DataApi({
+      adapter: new OttoAdapter({
+        auth: config.auth,
+        db: config.db,
+        server: config.server,
+      }),
+    });
+    const layoutName = "layout"; // Assuming "layout" is a valid layout in the test DB
+
+    // Call the method with only the required layout parameter
+    const response = await client.layoutMetadata({ layout: layoutName });
+
+    // Assertion 1: Ensure the call succeeded and returned a response object
+    expect(response).toBeDefined();
+    expect(response).toBeTypeOf("object");
+
+    // Assertion 2: Check for the presence of core metadata properties
+    expect(response).toHaveProperty("fieldMetaData");
+    expect(response).toHaveProperty("portalMetaData");
+    // valueLists is optional, check type if present
+    if (response.valueLists) {
+      expect(Array.isArray(response.valueLists)).toBe(true);
+    }
+
+    // Assertion 3: Verify the types of the core properties
+    expect(Array.isArray(response.fieldMetaData)).toBe(true);
+    expect(typeof response.portalMetaData).toBe("object");
+
+    // Assertion 4 (Optional but recommended): Check structure of metadata
+    if (response.fieldMetaData.length > 0) {
+      expect(response.fieldMetaData[0]).toHaveProperty("name");
+      expect(response.fieldMetaData[0]).toHaveProperty("type");
+    }
+  });
+
+  it("should retrieve layout metadata when layout is configured on the client", async () => {
+    const client = DataApi({
+      adapter: new OttoAdapter({
+        auth: config.auth,
+        db: config.db,
+        server: config.server,
+      }),
+      layout: "layout", // Configure layout on the client
+    });
+
+    // Call the method without the layout parameter (expecting it to use the client's layout)
+    // No arguments should be needed when layout is configured on the client.
+    const response = await client.layoutMetadata();
+
+    // Assertion 1: Ensure the call succeeded and returned a response object
+    expect(response).toBeDefined();
+    expect(response).toBeTypeOf("object");
+
+    // Assertion 2: Check for the presence of core metadata properties
+    expect(response).toHaveProperty("fieldMetaData");
+    expect(response).toHaveProperty("portalMetaData");
+    // valueLists is optional, check type if present
+    if (response.valueLists) {
+      expect(Array.isArray(response.valueLists)).toBe(true);
+    }
+
+    // Assertion 3: Verify the types of the core properties
+    expect(Array.isArray(response.fieldMetaData)).toBe(true);
+    expect(typeof response.portalMetaData).toBe("object");
+
+    // Assertion 4 (Optional but recommended): Check structure of metadata
+    if (response.fieldMetaData.length > 0) {
+      expect(response.fieldMetaData[0]).toHaveProperty("name");
+      expect(response.fieldMetaData[0]).toHaveProperty("type");
+    }
+  });
+
   it("should paginate through all records", async () => {
     const client = DataApi({
       adapter: new OttoAdapter({


### PR DESCRIPTION
Allow `layoutMetadata` to be called without arguments when layout is pre-configured on the client.